### PR TITLE
Add tekton resources to platform/, to be synced

### DIFF
--- a/platform/README.md
+++ b/platform/README.md
@@ -1,0 +1,22 @@
+# Platform
+
+This layer has cluster-wide or otherwise generic services, and the
+components used to enact and enforce policy (the particulars of which
+are in the layer above).
+
+In this case, the main article of platform is Tekton, which will drive
+standard pipelines defined in the policy layer.
+
+The Flux daemon running in substructure is also used to control the
+platform layer, here, because I'm on control of both of them. This may
+not be the case for other systems, where there's say an operations
+team provisioning the cluster and substructure, then other teams who
+can layer other stuff on top.
+
+The Tekton installation files were created by downloading a big YAML
+according to [the instructions][tekton-install], and running it
+through a `jk` script to a.) rewrite the namespace it lives in, and
+b.) put it all in separate files with nice names. See
+[./platform/tekton/index.js][].
+
+[tekton-install]: https://github.com/tektoncd/pipeline/blob/master/docs/install.md#installing-tekton-pipelines-on-kubernetes

--- a/platform/tekton/clustertasks.tekton.dev-customresourcedefinition.yaml
+++ b/platform/tekton/clustertasks.tekton.dev-customresourcedefinition.yaml
@@ -1,0 +1,23 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clustertasks.tekton.dev
+spec:
+  group: tekton.dev
+  names:
+    categories:
+    - tekton
+    - tekton-pipelines
+    kind: ClusterTask
+    plural: clustertasks
+  scope: Cluster
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false

--- a/platform/tekton/conditions.tekton.dev-customresourcedefinition.yaml
+++ b/platform/tekton/conditions.tekton.dev-customresourcedefinition.yaml
@@ -1,0 +1,16 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: conditions.tekton.dev
+spec:
+  group: tekton.dev
+  names:
+    categories:
+    - tekton
+    - tekton-pipelines
+    kind: Condition
+    plural: conditions
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1

--- a/platform/tekton/config-artifact-bucket-configmap.yaml
+++ b/platform/tekton/config-artifact-bucket-configmap.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-artifact-bucket
+  namespace: platform

--- a/platform/tekton/config-artifact-pvc-configmap.yaml
+++ b/platform/tekton/config-artifact-pvc-configmap.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-artifact-pvc
+  namespace: platform

--- a/platform/tekton/config-defaults-configmap.yaml
+++ b/platform/tekton/config-defaults-configmap.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+data:
+  _example: |-
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # default-timeout-minutes contains the default number of
+    # minutes to use for TaskRun and PipelineRun, if none is specified.
+    default-timeout-minutes: "60"  # 60 minutes
+
+    # default-service-account contains the default service account name
+    # to use for TaskRun and PipelineRun, if none is specified.
+    default-service-account: "default"
+
+    # default-managed-by-label-value contains the default value given to the
+    # "app.kubernetes.io/managed-by" label applied to all Pods created for
+    # TaskRuns. If a user's requested TaskRun specifies another value for this
+    # label, the user's request supercedes.
+    default-managed-by-label-value: "tekton-pipelines"
+
+    # default-pod-template contains the default pod template to use
+    # TaskRun and PipelineRun, if none is specified. If a pod template
+    # is specified, the default pod template is ignored.
+    # default-pod-template:
+kind: ConfigMap
+metadata:
+  name: config-defaults
+  namespace: platform

--- a/platform/tekton/config-logging-configmap.yaml
+++ b/platform/tekton/config-logging-configmap.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+data:
+  loglevel.controller: info
+  loglevel.webhook: info
+  zap-logger-config: |
+    {
+      "level": "info",
+      "development": false,
+      "sampling": {
+        "initial": 100,
+        "thereafter": 100
+      },
+      "outputPaths": ["stdout"],
+      "errorOutputPaths": ["stderr"],
+      "encoding": "json",
+      "encoderConfig": {
+        "timeKey": "",
+        "levelKey": "level",
+        "nameKey": "logger",
+        "callerKey": "caller",
+        "messageKey": "msg",
+        "stacktraceKey": "stacktrace",
+        "lineEnding": "",
+        "levelEncoder": "",
+        "timeEncoder": "",
+        "durationEncoder": "",
+        "callerEncoder": ""
+      }
+    }
+kind: ConfigMap
+metadata:
+  name: config-logging
+  namespace: platform

--- a/platform/tekton/config-observability-configmap.yaml
+++ b/platform/tekton/config-observability-configmap.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # metrics.backend-destination field specifies the system metrics destination.
+    # It supports either prometheus (the default) or stackdriver.
+    # Note: Using Stackdriver will incur additional charges.
+    metrics.backend-destination: prometheus
+
+    # metrics.stackdriver-project-id field specifies the Stackdriver project ID. This
+    # field is optional. When running on GCE, application default credentials will be
+    # used and metrics will be sent to the cluster's project if this field is
+    # not provided.
+    metrics.stackdriver-project-id: "<your stackdriver project id>"
+
+    # metrics.allow-stackdriver-custom-metrics indicates whether it is allowed
+    # to send metrics to Stackdriver using "global" resource type and custom
+    # metric type. Setting this flag to "true" could cause extra Stackdriver
+    # charge.  If metrics.backend-destination is not Stackdriver, this is
+    # ignored.
+    metrics.allow-stackdriver-custom-metrics: "false"
+kind: ConfigMap
+metadata:
+  name: config-observability
+  namespace: platform

--- a/platform/tekton/config.webhook.pipeline.tekton.dev-validatingwebhookconfiguration.yaml
+++ b/platform/tekton/config.webhook.pipeline.tekton.dev-validatingwebhookconfiguration.yaml
@@ -1,0 +1,20 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    pipeline.tekton.dev/release: devel
+  name: config.webhook.pipeline.tekton.dev
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: tekton-pipelines-webhook
+      namespace: platform
+  failurePolicy: Fail
+  name: config.webhook.pipeline.tekton.dev
+  namespaceSelector:
+    matchExpressions:
+    - key: pipeline.tekton.dev/release
+      operator: Exists
+  sideEffects: None

--- a/platform/tekton/feature-flags-configmap.yaml
+++ b/platform/tekton/feature-flags-configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  disable-home-env-overwrite: "false"
+  disable-working-directory-overwrite: "false"
+kind: ConfigMap
+metadata:
+  name: feature-flags
+  namespace: platform

--- a/platform/tekton/images.caching.internal.knative.dev-customresourcedefinition.yaml
+++ b/platform/tekton/images.caching.internal.knative.dev-customresourcedefinition.yaml
@@ -1,0 +1,21 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    knative.dev/crd-install: "true"
+  name: images.caching.internal.knative.dev
+spec:
+  group: caching.internal.knative.dev
+  names:
+    categories:
+    - knative-internal
+    - caching
+    kind: Image
+    plural: images
+    shortNames:
+    - img
+    singular: image
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1

--- a/platform/tekton/index.js
+++ b/platform/tekton/index.js
@@ -1,0 +1,64 @@
+// Script to rewrite Tekton release YAML to be where I want it.
+//
+// This is for use with `jk generate`, e.g.,
+//
+//     curl curl -L https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml | \
+//       jk generate --lib jkcfg/kubernetes ./platform/tekton/ --stdout
+//
+// (and use `-o platform` to put it all in individual files).
+
+
+import { valuesForGenerate } from '@jkcfg/kubernetes/generate';
+import { read, Format } from '@jkcfg/std';
+import { merge, deepWithKey } from '@jkcfg/std/merge';
+import * as param from '@jkcfg/std/param';
+
+const newNamespace = param.String('namespace', 'platform');
+
+// mergeMap assumes the left-hand value is an array, and merges each
+// item with the right-hand value (using the given rules) to get
+// another array.
+function mergeMap(rules) {
+  return (v1, v2) => v1.map(v => merge(v, v2, rules));
+}
+
+function renamespace(v) {
+  // The namespace declaration itself
+  if (v.kind === 'Namespace') {
+    return merge(v, { metadata: { name: newNamespace } });
+  }
+
+  // A cluster role binding subject will have a namespace, but aren't
+  // namespaced themselves.
+  if (v.kind === 'ClusterRoleBinding') {
+    return merge(v, {
+      subjects: [{ name: 'tekton-pipelines-controller', namespace: newNamespace }]
+    }, { subjects: deepWithKey('name') });
+  }
+
+  // Webhooks have a namespaced clientConfig, but aren't namespaced
+  // themselves.
+  if (v.kind === 'ValidatingWebhookConfiguration' ||
+      v.kind === 'MutatingWebhookConfiguration') {
+    return merge(v, {
+      webhooks: {
+        clientConfig: {
+          service: {
+            namespace: newNamespace,
+          },
+        },
+      },
+    }, { webhooks : mergeMap() });
+  }
+
+  // Anything else: if it has a namespace, give it the new namespace.
+  if (v.metadata.namespace) {
+    return merge(v, { metadata: { namespace: newNamespace } });
+  }
+  return v;
+}
+
+export default read('' /* stdin */, { format: Format.YAMLStream })
+  .then(values => values.filter(v => v)
+        .map(renamespace))
+  .then(valuesForGenerate);

--- a/platform/tekton/pipelineresources.tekton.dev-customresourcedefinition.yaml
+++ b/platform/tekton/pipelineresources.tekton.dev-customresourcedefinition.yaml
@@ -1,0 +1,16 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: pipelineresources.tekton.dev
+spec:
+  group: tekton.dev
+  names:
+    categories:
+    - tekton
+    - tekton-pipelines
+    kind: PipelineResource
+    plural: pipelineresources
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1

--- a/platform/tekton/pipelineruns.tekton.dev-customresourcedefinition.yaml
+++ b/platform/tekton/pipelineruns.tekton.dev-customresourcedefinition.yaml
@@ -1,0 +1,39 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: pipelineruns.tekton.dev
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=="Succeeded")].status
+    name: Succeeded
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Succeeded")].reason
+    name: Reason
+    type: string
+  - JSONPath: .status.startTime
+    name: StartTime
+    type: date
+  - JSONPath: .status.completionTime
+    name: CompletionTime
+    type: date
+  group: tekton.dev
+  names:
+    categories:
+    - tekton
+    - tekton-pipelines
+    kind: PipelineRun
+    plural: pipelineruns
+    shortNames:
+    - pr
+    - prs
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false

--- a/platform/tekton/pipelines.tekton.dev-customresourcedefinition.yaml
+++ b/platform/tekton/pipelines.tekton.dev-customresourcedefinition.yaml
@@ -1,0 +1,23 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: pipelines.tekton.dev
+spec:
+  group: tekton.dev
+  names:
+    categories:
+    - tekton
+    - tekton-pipelines
+    kind: Pipeline
+    plural: pipelines
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false

--- a/platform/tekton/platform-namespace.yaml
+++ b/platform/tekton/platform-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: platform

--- a/platform/tekton/taskruns.tekton.dev-customresourcedefinition.yaml
+++ b/platform/tekton/taskruns.tekton.dev-customresourcedefinition.yaml
@@ -1,0 +1,39 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: taskruns.tekton.dev
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=="Succeeded")].status
+    name: Succeeded
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Succeeded")].reason
+    name: Reason
+    type: string
+  - JSONPath: .status.startTime
+    name: StartTime
+    type: date
+  - JSONPath: .status.completionTime
+    name: CompletionTime
+    type: date
+  group: tekton.dev
+  names:
+    categories:
+    - tekton
+    - tekton-pipelines
+    kind: TaskRun
+    plural: taskruns
+    shortNames:
+    - tr
+    - trs
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false

--- a/platform/tekton/tasks.tekton.dev-customresourcedefinition.yaml
+++ b/platform/tekton/tasks.tekton.dev-customresourcedefinition.yaml
@@ -1,0 +1,23 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: tasks.tekton.dev
+spec:
+  group: tekton.dev
+  names:
+    categories:
+    - tekton
+    - tekton-pipelines
+    kind: Task
+    plural: tasks
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false

--- a/platform/tekton/tekton-aggregate-edit-clusterrole.yaml
+++ b/platform/tekton/tekton-aggregate-edit-clusterrole.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: tekton-aggregate-edit
+rules:
+- apiGroups:
+  - tekton.dev
+  resources:
+  - tasks
+  - taskruns
+  - pipelines
+  - pipelineruns
+  - pipelineresources
+  - conditions
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/platform/tekton/tekton-aggregate-view-clusterrole.yaml
+++ b/platform/tekton/tekton-aggregate-view-clusterrole.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: tekton-aggregate-view
+rules:
+- apiGroups:
+  - tekton.dev
+  resources:
+  - tasks
+  - taskruns
+  - pipelines
+  - pipelineruns
+  - pipelineresources
+  - conditions
+  verbs:
+  - get
+  - list
+  - watch

--- a/platform/tekton/tekton-pipelines-admin-clusterrole.yaml
+++ b/platform/tekton/tekton-pipelines-admin-clusterrole.yaml
@@ -1,0 +1,118 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tekton-pipelines-admin
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/log
+  - namespaces
+  - secrets
+  - events
+  - serviceaccounts
+  - configmaps
+  - persistentvolumeclaims
+  - limitranges
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - tasks
+  - clustertasks
+  - taskruns
+  - pipelines
+  - pipelineruns
+  - pipelineresources
+  - conditions
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - taskruns/finalizers
+  - pipelineruns/finalizers
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - tasks/status
+  - clustertasks/status
+  - taskruns/status
+  - pipelines/status
+  - pipelineruns/status
+  - pipelineresources/status
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - policy
+  resourceNames:
+  - tekton-pipelines
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use

--- a/platform/tekton/tekton-pipelines-controller-admin-clusterrolebinding.yaml
+++ b/platform/tekton/tekton-pipelines-controller-admin-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-pipelines-controller-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-pipelines-admin
+subjects:
+- kind: ServiceAccount
+  name: tekton-pipelines-controller
+  namespace: platform

--- a/platform/tekton/tekton-pipelines-controller-deployment.yaml
+++ b/platform/tekton/tekton-pipelines-controller-deployment.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: tekton-pipelines
+    pipeline.tekton.dev/release: v0.11.0-rc1
+    version: v0.11.0-rc1
+  name: tekton-pipelines-controller
+  namespace: platform
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tekton-pipelines-controller
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+      labels:
+        app: tekton-pipelines-controller
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/name: tekton-pipelines
+        pipeline.tekton.dev/release: v0.11.0-rc1
+        version: v0.11.0-rc1
+    spec:
+      containers:
+      - args:
+        - -kubeconfig-writer-image
+        - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/kubeconfigwriter:v0.11.0-rc1@sha256:66ff7dd82f77a9e7a5f5fbc6783baf5af732bb4428e0c7293ce7c285bd06f90e
+        - -creds-image
+        - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init:v0.11.0-rc1@sha256:d1251c017ad8db911f6b459f9cbe94328c962b619b5a6e4ef57524254c1dc30d
+        - -git-image
+        - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.11.0-rc1@sha256:90bab5bf608890d086942890681d84faf82c1cc766c97ad95e309c50bdac3121
+        - -nop-image
+        - tianon/true
+        - -shell-image
+        - busybox
+        - -gsutil-image
+        - google/cloud-sdk
+        - -entrypoint-image
+        - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.11.0-rc1@sha256:4c6b3559819aa9e32b8b6b506140115a93e66fd513036c1d20f3426f5e405be1
+        - -imagedigest-exporter-image
+        - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/imagedigestexporter:v0.11.0-rc1@sha256:8b339a57f2080c6d017636317e368cca3c9124f0fe14af98e53d1dc446bb897e
+        - -pr-image
+        - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/pullrequest-init:v0.11.0-rc1@sha256:62388b0dd5fd3b12444e454cdb6ec967afb557dd2131a9f94bb7bb98761b5f35
+        - -build-gcs-fetcher-image
+        - gcr.io/tekton-releases/github.com/tektoncd/pipeline/vendor/github.com/googlecloudplatform/cloud-builders/gcs-fetcher/cmd/gcs-fetcher:v0.11.0-rc1@sha256:74fd88bb0c4810483bdbbfb779d9ad01324145d5e3e63c4c9271c61ae0d4e1c7
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: CONFIG_ARTIFACT_BUCKET_NAME
+          value: config-artifact-bucket
+        - name: CONFIG_ARTIFACT_PVC_NAME
+          value: config-artifact-pvc
+        - name: METRICS_DOMAIN
+          value: tekton.dev/pipeline
+        image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/controller:v0.11.0-rc1@sha256:786a306a2645186ad2c547db2cfc3e1987cd31962166dc320c908d10ebe903b9
+        name: tekton-pipelines-controller
+        volumeMounts:
+        - mountPath: /etc/config-logging
+          name: config-logging
+      serviceAccountName: tekton-pipelines-controller
+      volumes:
+      - configMap:
+          name: config-logging
+        name: config-logging

--- a/platform/tekton/tekton-pipelines-controller-service.yaml
+++ b/platform/tekton/tekton-pipelines-controller-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: tekton-pipelines-controller
+    pipeline.tekton.dev/release: v0.11.0-rc1
+    version: v0.11.0-rc1
+  name: tekton-pipelines-controller
+  namespace: platform
+spec:
+  ports:
+  - name: http-metrics
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
+  selector:
+    app: tekton-pipelines-controller

--- a/platform/tekton/tekton-pipelines-controller-serviceaccount.yaml
+++ b/platform/tekton/tekton-pipelines-controller-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tekton-pipelines-controller
+  namespace: platform

--- a/platform/tekton/tekton-pipelines-podsecuritypolicy.yaml
+++ b/platform/tekton/tekton-pipelines-podsecuritypolicy.yaml
@@ -1,0 +1,28 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: tekton-pipelines
+spec:
+  allowPrivilegeEscalation: false
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  hostIPC: false
+  hostNetwork: false
+  hostPID: false
+  privileged: false
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - emptyDir
+  - configMap
+  - secret

--- a/platform/tekton/tekton-pipelines-webhook-deployment.yaml
+++ b/platform/tekton/tekton-pipelines-webhook-deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: webhook-controller
+    app.kubernetes.io/name: tekton-pipelines
+    pipeline.tekton.dev/release: v0.11.0-rc1
+    version: v0.11.0-rc1
+  name: tekton-pipelines-webhook
+  namespace: platform
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tekton-pipelines-webhook
+      role: webhook
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+      labels:
+        app: tekton-pipelines-webhook
+        app.kubernetes.io/component: webhook-controller
+        app.kubernetes.io/name: tekton-pipelines
+        pipeline.tekton.dev/release: v0.11.0-rc1
+        role: webhook
+        version: v0.11.0-rc1
+    spec:
+      containers:
+      - env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: WEBHOOK_SERVICE_NAME
+          value: tekton-pipelines-webhook
+        - name: METRICS_DOMAIN
+          value: tekton.dev/pipeline
+        image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/webhook:v0.11.0-rc1@sha256:06d797f5456bfcd2c0bf50d701d899c6ad286dddf4d334c554c8e3e0c6949ca8
+        name: webhook
+        ports:
+        - containerPort: 9090
+          name: metrics
+        - containerPort: 8008
+          name: profiling
+        - containerPort: 8443
+          name: https-webhook
+        securityContext:
+          allowPrivilegeEscalation: false
+      serviceAccountName: tekton-pipelines-controller

--- a/platform/tekton/tekton-pipelines-webhook-service.yaml
+++ b/platform/tekton/tekton-pipelines-webhook-service.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: tekton-pipelines-webhook
+    pipeline.tekton.dev/release: v0.11.0-rc1
+    role: webhook
+    version: v0.11.0-rc1
+  name: tekton-pipelines-webhook
+  namespace: platform
+spec:
+  ports:
+  - name: http-metrics
+    port: 9090
+    targetPort: 9090
+  - name: http-profiling
+    port: 8008
+    targetPort: 8008
+  - name: https-webhook
+    port: 443
+    targetPort: 8443
+  selector:
+    app: tekton-pipelines-webhook
+    role: webhook

--- a/platform/tekton/validation.webhook.pipeline.tekton.dev-validatingwebhookconfiguration.yaml
+++ b/platform/tekton/validation.webhook.pipeline.tekton.dev-validatingwebhookconfiguration.yaml
@@ -1,0 +1,16 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    pipeline.tekton.dev/release: devel
+  name: validation.webhook.pipeline.tekton.dev
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: tekton-pipelines-webhook
+      namespace: platform
+  failurePolicy: Fail
+  name: validation.webhook.pipeline.tekton.dev
+  sideEffects: None

--- a/platform/tekton/webhook-certs-secret.yaml
+++ b/platform/tekton/webhook-certs-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    pipeline.tekton.dev/release: devel
+  name: webhook-certs
+  namespace: platform

--- a/platform/tekton/webhook.pipeline.tekton.dev-mutatingwebhookconfiguration.yaml
+++ b/platform/tekton/webhook.pipeline.tekton.dev-mutatingwebhookconfiguration.yaml
@@ -1,0 +1,16 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    pipeline.tekton.dev/release: devel
+  name: webhook.pipeline.tekton.dev
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: tekton-pipelines-webhook
+      namespace: platform
+  failurePolicy: Fail
+  name: webhook.pipeline.tekton.dev
+  sideEffects: None

--- a/substructure/flux-deployment.yaml
+++ b/substructure/flux-deployment.yaml
@@ -136,6 +136,7 @@ spec:
         - --git-url=git@github.com:squaremo/cuttlefacts
         - --git-branch=master
         - --git-path=substructure
+        - --git-path=platform
         - --git-label=flux
         - --git-user=Flux
         - --git-email=michael+cuttlefacts@weave.works


### PR DESCRIPTION
This adds the one million Tekton resources as files to be synced by
the substructure Flux daemon (as well as changing its config so it'll
sync platform/ as well).