### PR TITLE
Introduce policy layer

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -1,5 +1,5 @@
 # Application layer
 
-The configuration in this directory is what runs the application. For
-our purposes, this is a vanilla deployment and service, with the
-deployment running the image built from [../src/][].
+The configuration in each directory here runs an application. For our
+purposes, `cuttlefacts/` has a vanilla deployment and service, with
+the deployment running the image built from [../src/][].

--- a/app/cuttlefacts/deployment.yaml
+++ b/app/cuttlefacts/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cuttlefacts
-  namespace: app
+  namespace: cuttlefacts
 spec:
   replicas: 1
   selector:

--- a/app/cuttlefacts/service.yaml
+++ b/app/cuttlefacts/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: cuttlefacts
-  namespace: app
+  namespace: cuttlefacts
 spec:
   ports:
   - name: http

--- a/policy/README.md
+++ b/policy/README.md
@@ -1,0 +1,46 @@
+# Policy layer
+
+This layer enables and enforces policy for the cluster. Here, "policy"
+means all the decisions that are set about how applications are
+delivered into and run in the cluster, as opposed to the substance of
+the applications themselves.
+
+This layer is distinct from the `platform` below it, which is generic
+machinery upon which policy depends, and `app` above it, which runs
+the application code.
+
+For our purposes, policy will boil down to:
+
+ - standard pipelines, triggers, and task definitions;
+ - for each app in the app layer (i.e., [`cuttlefacts/`][]):
+   - a namespace for it to live in;
+   - a Flux deployment that will sync its configuration;
+   - any instances of pipelines or triggers that are
+     necessary to deliver the application code into the cluster.
+
+## Flux
+
+Each application gets a Flux daemon to sync configuration from its git
+repo. For `cuttlefacts` I ran the following:
+
+    fluxctl install --namespace=policy \
+      --git-readonly --registry-disable-scanning \
+      --git-url https://github.com/squaremo/cuttlefacts \
+      --git-email "example@example.com" > policy/cuttlefacts/flux.yaml
+
+then edited it to remove unnecessary volumes and so on.
+
+I also removed the generated RBAC definitions, which give wide-ranging
+permissions, and created a new set as described below.
+
+### Authorisation in the policy layer
+
+I have not attempted to nail down the permissions, just to demonstrate
+that authorisation can be set in the policy layer.
+
+ - There is a `ClusterRole` defining the authorisation needed by Flux
+   within a given namespace
+ - Each application Flux daemon runs in the `policy` namespace and is
+   given its own service account.
+ - Each application Flux's service account has a RoleBinding to the
+   generic `ClusterRole`, narrowing it to the _application_ namespace.

--- a/policy/cuttlefacts/flux.yaml
+++ b/policy/cuttlefacts/flux.yaml
@@ -1,0 +1,231 @@
+---
+# The service account, cluster roles, and cluster role binding are
+# only needed for Kubernetes with role-based access control (RBAC).
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    name: flux
+  name: flux
+  namespace: policy
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    name: flux
+  name: flux
+rules:
+  - apiGroups: ['*']
+    resources: ['*']
+    verbs: ['*']
+  - nonResourceURLs: ['*']
+    verbs: ['*']
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    name: flux
+  name: flux
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flux
+subjects:
+  - kind: ServiceAccount
+    name: flux
+    namespace: policy
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: flux
+  namespace: policy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: flux
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: "3031" # tell prometheus to scrape /metrics endpoint's port.
+      labels:
+        name: flux
+    spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      serviceAccountName: flux
+      volumes:
+      - name: git-key
+        secret:
+          secretName: flux-git-deploy
+          defaultMode: 0400 # when mounted read-only, we won't be able to chmod
+
+      # This is a tmpfs used for generating SSH keys. In K8s >= 1.10,
+      # mounted secrets are read-only, so we need a separate volume we
+      # can write to.
+      - name: git-keygen
+        emptyDir:
+          medium: Memory
+
+      # The following volume is for using a customised known_hosts
+      # file, which you will need to do if you host your own git
+      # repo rather than using github or the like. You'll also need to
+      # mount it into the container, below. See
+      # https://docs.fluxcd.io/en/latest/guides/use-private-git-host.html
+      # - name: ssh-config
+      #   configMap:
+      #     name: flux-ssh-config
+
+      # The following volume is for using a customised .kube/config,
+      # which you will need to do if you wish to have a different
+      # default namespace. You will also need to provide the configmap
+      # with an entry for `config`, and uncomment the volumeMount and
+      # env entries below.
+      # - name: kubeconfig
+      #   configMap:
+      #     name: flux-kubeconfig
+
+      # The following volume is used to import GPG keys (for signing
+      # and verification purposes). You will also need to provide the
+      # secret with the keys, and uncomment the volumeMount and args
+      # below.
+      # - name: gpg-keys
+      #   secret:
+      #     secretName: flux-gpg-keys
+      #     defaultMode: 0400
+
+      containers:
+      - name: flux
+        # There are no ":latest" images for flux. Find the most recent
+        # release or image version at https://hub.docker.com/r/fluxcd/flux/tags
+        # and replace the tag here.
+        image: docker.io/fluxcd/flux:1.18.0
+        imagePullPolicy: IfNotPresent
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+        ports:
+        - containerPort: 3030 # informational
+        livenessProbe:
+          httpGet:
+            port: 3030
+            path: /api/flux/v6/identity.pub
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            port: 3030
+            path: /api/flux/v6/identity.pub
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        volumeMounts:
+        - name: git-key
+          mountPath: /etc/fluxd/ssh # to match location given in image's /etc/ssh/config
+          readOnly: true # this will be the case perforce in K8s >=1.10
+        - name: git-keygen
+          mountPath: /var/fluxd/keygen # to match location given in image's /etc/ssh/config
+
+        # Include this if you need to mount a customised known_hosts
+        # file; you'll also need the volume declared above.
+        # - name: ssh-config
+        #   mountPath: /root/.ssh
+
+        # Include this and the volume "kubeconfig" above, and the
+        # environment entry "KUBECONFIG" below, to override the config
+        # used by kubectl.
+        # - name: kubeconfig
+        #   mountPath: /etc/fluxd/kube
+
+        # Include this to point kubectl at a different config; you
+        # will need to do this if you have mounted an alternate config
+        # from a configmap, as in commented blocks above.
+        # env:
+        # - name: KUBECONFIG
+        #   value: /etc/fluxd/kube/config
+
+        # Include this and the volume "gpg-keys" above, and the
+        # args below.
+        # - name: gpg-keys
+        #   mountPath: /root/gpg-import
+        #   readOnly: true
+
+        # Include this if you want to supply HTTP basic auth credentials for git
+        # via the `GIT_AUTHUSER` and `GIT_AUTHKEY` environment variables using a
+        # secret.
+        # envFrom:
+        # - secretRef:
+        #     name: flux-git-auth
+
+        args:
+
+        # If you deployed memcached in a different namespace to flux,
+        # or with a different service name, you can supply these
+        # following two arguments to tell fluxd how to connect to it.
+        # - --memcached-hostname=memcached.default.svc.cluster.local
+
+        # Use the memcached ClusterIP service name by setting the
+        # memcached-service to string empty
+        - --memcached-service=
+
+        # This must be supplied, and be in the tmpfs (emptyDir)
+        # mounted above, for K8s >= 1.10
+        - --ssh-keygen-dir=/var/fluxd/keygen
+
+        # Replace the following URL to change the Git repository used by Flux.
+        # HTTP basic auth credentials can be supplied using environment variables:
+        # https://$(GIT_AUTHUSER):$(GIT_AUTHKEY)@github.com/user/repository.git
+        - --git-url=https://github.com/squaremo/cuttlefacts
+        - --git-branch=master
+        # Include this if you want to restrict the manifests considered by flux
+        # to those under the following relative paths in the git repository
+        # - --git-path=subdir1,subdir2
+        - --git-label=flux
+        - --git-user=Flux
+        - --git-email=example@example.com
+
+        # Include these two to enable git commit signing
+        # - --git-gpg-key-import=/root/gpg-import
+        # - --git-signing-key=<key id>
+        
+        # Include this to enable git signature verification
+        # - --git-verify-signatures
+
+        # Tell flux it has readonly access to the repo (default `false`)
+        - --git-readonly
+
+        # Instruct flux where to put sync bookkeeping (default "git", meaning use a tag in the upstream git repo)
+        # - --sync-state=git
+
+        # Include these next two to connect to an "upstream" service
+        # (e.g., Weave Cloud). The token is particular to the service.
+        # - --connect=wss://cloud.weave.works/api/flux
+        # - --token=abc123abc123abc123abc123
+
+        # Enable manifest generation (default `false`)
+        # - --manifest-generation=false
+
+        # Serve /metrics endpoint at different port;
+        # make sure to set prometheus' annotation to scrape the port value.
+        - --listen-metrics=:3031
+        - --registry-disable-scanning
+
+      # Optional DNS settings, configuring the ndots option may resolve
+      # nslookup issues on some Kubernetes setups.
+      # dnsPolicy: "None"
+      # dnsConfig:
+      #   options:
+      #     - name: ndots
+      #       value: "1"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: flux-git-deploy
+  namespace: policy
+type: Opaque

--- a/policy/cuttlefacts/flux.yaml
+++ b/policy/cuttlefacts/flux.yaml
@@ -1,52 +1,41 @@
+# See the policy/README.md for how RBAC is arranged for running Flux
+# for an application
 ---
-# The service account, cluster roles, and cluster role binding are
-# only needed for Kubernetes with role-based access control (RBAC).
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
     name: flux
-  name: flux
+  name: flux-cuttlefacts
   namespace: policy
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
+kind: RoleBinding
 metadata:
   labels:
     name: flux
-  name: flux
-rules:
-  - apiGroups: ['*']
-    resources: ['*']
-    verbs: ['*']
-  - nonResourceURLs: ['*']
-    verbs: ['*']
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  labels:
-    name: flux
+    namespace: cuttlefacts
   name: flux
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: flux
+  name: flux-application
 subjects:
   - kind: ServiceAccount
-    name: flux
+    name: flux-cuttlefacts
     namespace: policy
+
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: flux
+  name: flux-cuttlefacts
   namespace: policy
 spec:
   replicas: 1
   selector:
     matchLabels:
-      name: flux
+      name: flux-cuttlefacts
   strategy:
     type: Recreate
   template:
@@ -54,50 +43,11 @@ spec:
       annotations:
         prometheus.io/port: "3031" # tell prometheus to scrape /metrics endpoint's port.
       labels:
-        name: flux
+        name: flux-cuttlefacts
     spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
-      serviceAccountName: flux
-      volumes:
-      - name: git-key
-        secret:
-          secretName: flux-git-deploy
-          defaultMode: 0400 # when mounted read-only, we won't be able to chmod
-
-      # This is a tmpfs used for generating SSH keys. In K8s >= 1.10,
-      # mounted secrets are read-only, so we need a separate volume we
-      # can write to.
-      - name: git-keygen
-        emptyDir:
-          medium: Memory
-
-      # The following volume is for using a customised known_hosts
-      # file, which you will need to do if you host your own git
-      # repo rather than using github or the like. You'll also need to
-      # mount it into the container, below. See
-      # https://docs.fluxcd.io/en/latest/guides/use-private-git-host.html
-      # - name: ssh-config
-      #   configMap:
-      #     name: flux-ssh-config
-
-      # The following volume is for using a customised .kube/config,
-      # which you will need to do if you wish to have a different
-      # default namespace. You will also need to provide the configmap
-      # with an entry for `config`, and uncomment the volumeMount and
-      # env entries below.
-      # - name: kubeconfig
-      #   configMap:
-      #     name: flux-kubeconfig
-
-      # The following volume is used to import GPG keys (for signing
-      # and verification purposes). You will also need to provide the
-      # secret with the keys, and uncomment the volumeMount and args
-      # below.
-      # - name: gpg-keys
-      #   secret:
-      #     secretName: flux-gpg-keys
-      #     defaultMode: 0400
+      serviceAccountName: flux-cuttlefacts
 
       containers:
       - name: flux
@@ -124,104 +74,36 @@ spec:
             path: /api/flux/v6/identity.pub
           initialDelaySeconds: 5
           timeoutSeconds: 5
-        volumeMounts:
-        - name: git-key
-          mountPath: /etc/fluxd/ssh # to match location given in image's /etc/ssh/config
-          readOnly: true # this will be the case perforce in K8s >=1.10
-        - name: git-keygen
-          mountPath: /var/fluxd/keygen # to match location given in image's /etc/ssh/config
-
-        # Include this if you need to mount a customised known_hosts
-        # file; you'll also need the volume declared above.
-        # - name: ssh-config
-        #   mountPath: /root/.ssh
-
-        # Include this and the volume "kubeconfig" above, and the
-        # environment entry "KUBECONFIG" below, to override the config
-        # used by kubectl.
-        # - name: kubeconfig
-        #   mountPath: /etc/fluxd/kube
-
-        # Include this to point kubectl at a different config; you
-        # will need to do this if you have mounted an alternate config
-        # from a configmap, as in commented blocks above.
-        # env:
-        # - name: KUBECONFIG
-        #   value: /etc/fluxd/kube/config
-
-        # Include this and the volume "gpg-keys" above, and the
-        # args below.
-        # - name: gpg-keys
-        #   mountPath: /root/gpg-import
-        #   readOnly: true
-
-        # Include this if you want to supply HTTP basic auth credentials for git
-        # via the `GIT_AUTHUSER` and `GIT_AUTHKEY` environment variables using a
-        # secret.
-        # envFrom:
-        # - secretRef:
-        #     name: flux-git-auth
 
         args:
 
-        # If you deployed memcached in a different namespace to flux,
-        # or with a different service name, you can supply these
-        # following two arguments to tell fluxd how to connect to it.
-        # - --memcached-hostname=memcached.default.svc.cluster.local
-
-        # Use the memcached ClusterIP service name by setting the
-        # memcached-service to string empty
-        - --memcached-service=
-
-        # This must be supplied, and be in the tmpfs (emptyDir)
-        # mounted above, for K8s >= 1.10
-        - --ssh-keygen-dir=/var/fluxd/keygen
+        # Restrict to just the application namespace
+        - --k8s-allow-namespace=cuttlefacts
 
         # Replace the following URL to change the Git repository used by Flux.
         # HTTP basic auth credentials can be supplied using environment variables:
         # https://$(GIT_AUTHUSER):$(GIT_AUTHKEY)@github.com/user/repository.git
         - --git-url=https://github.com/squaremo/cuttlefacts
-        - --git-branch=master
+        - --git-branch=policy-layer # <--- CHANGE ME
         # Include this if you want to restrict the manifests considered by flux
         # to those under the following relative paths in the git repository
-        # - --git-path=subdir1,subdir2
-        - --git-label=flux
-        - --git-user=Flux
-        - --git-email=example@example.com
+        - --git-path=app/cuttlefacts
 
         # Include these two to enable git commit signing
         # - --git-gpg-key-import=/root/gpg-import
         # - --git-signing-key=<key id>
-        
+
         # Include this to enable git signature verification
         # - --git-verify-signatures
 
         # Tell flux it has readonly access to the repo (default `false`)
         - --git-readonly
 
-        # Instruct flux where to put sync bookkeeping (default "git", meaning use a tag in the upstream git repo)
-        # - --sync-state=git
-
-        # Include these next two to connect to an "upstream" service
-        # (e.g., Weave Cloud). The token is particular to the service.
-        # - --connect=wss://cloud.weave.works/api/flux
-        # - --token=abc123abc123abc123abc123
-
-        # Enable manifest generation (default `false`)
-        # - --manifest-generation=false
-
         # Serve /metrics endpoint at different port;
         # make sure to set prometheus' annotation to scrape the port value.
         - --listen-metrics=:3031
         - --registry-disable-scanning
 
-      # Optional DNS settings, configuring the ndots option may resolve
-      # nslookup issues on some Kubernetes setups.
-      # dnsPolicy: "None"
-      # dnsConfig:
-      #   options:
-      #     - name: ndots
-      #       value: "1"
 ---
 apiVersion: v1
 kind: Secret

--- a/policy/cuttlefacts/namespace.yaml
+++ b/policy/cuttlefacts/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cuttlefacts

--- a/policy/flux-clusterrole.yaml
+++ b/policy/flux-clusterrole.yaml
@@ -1,0 +1,18 @@
+# This is a cluster role giving the permissions that an
+# application-syncing Flux needs _within_ a namespace. It's a cluster
+# role so that it can be referred to by a RoleBinding in each
+# application namespace (which narrows the permissions to that
+# namespace).
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    name: flux
+  name: flux-application
+rules:
+  - apiGroups: ['*']
+    resources: ['*']
+    verbs: ['*']
+  - nonResourceURLs: ['*']
+    verbs: ['*']

--- a/policy/namespace.yaml
+++ b/policy/namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: app
+  name: policy


### PR DESCRIPTION
From the README:

> This layer enables and enforces policy for the cluster. Here, "policy"
> means all the decisions that are set about how applications are
> delivered into and run in the cluster, as opposed to the substance of
> the applications themselves.
>
> This layer is distinct from the `platform` below it, which is generic
> machinery upon which policy depends, and `app` above it, which runs
> the application code.
>
> For our purposes, policy will boil down to:
>
>  - standard pipelines, triggers, and task definitions;
>  - for each app in the app layer (i.e., [`cuttlefacts/`][]):
>    - a namespace for it to live in;
>    - a Flux deployment that will sync its configuration;
>    - any instances of pipelines or triggers that are
>      necessary to deliver the application code into the cluster.

This PR does the first two line items, that is a namespace and a Flux for the application (cuttlefacts).