### PR TITLE
Sync policy layer from infrastructural Flux

### DIFF
--- a/substructure/flux-deployment.yaml
+++ b/substructure/flux-deployment.yaml
@@ -139,6 +139,7 @@ spec:
         - --git-branch=master
         - --git-path=substructure
         - --git-path=platform
+        - --git-path=policy
 
         # Include these two to enable git commit signing
         # - --git-gpg-key-import=/root/gpg-import


### PR DESCRIPTION
The general principle of the layering is that each layer instantiates
the one above it. E.g., substructure syncs the definitions for
platform.

The difference between platform and policy is mechanism vs
particulars, but it's a thin distinction. To keep things moving, I'm
going to conflate them with respect to instantiation, and just tell
the Flux in infrastructure to sync policy/ as well.