### PR TITLE
Name flux's git secret for the app

### DIFF
--- a/policy/cuttlefacts/flux.yaml
+++ b/policy/cuttlefacts/flux.yaml
@@ -101,6 +101,10 @@ spec:
         # Tell flux it has readonly access to the repo (default `false`)
         - --git-readonly
 
+        # We don't need the secret to hold a key, but we do want to
+        # poke the HWM into an annotation
+        - --k8s-secret-name=cuttlefacts-git
+
         # Serve /metrics endpoint at different port;
         # make sure to set prometheus' annotation to scrape the port value.
         - --listen-metrics=:3031
@@ -110,6 +114,6 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: flux-git-deploy
+  name: cuttlefacts-git
   namespace: policy
 type: Opaque


### PR DESCRIPTION
I'm not using a deploy key, but I do need somewhere for fluxd to write
the sync high water mark. This makes the secret in the high water mark
particular to the cuttlefacts app.